### PR TITLE
segmentation fault if host unknown

### DIFF
--- a/src/mysql-udf-http.c
+++ b/src/mysql-udf-http.c
@@ -112,7 +112,8 @@ void http_get_deinit(UDF_INIT *initid)
   /* if we allocated initid->ptr, free it here */
   st_curl_results *res= (st_curl_results *)initid->ptr;
 
-  free(res->result);
+  if (res->result)
+        free(res->result);
   free(res);
   return;
 }
@@ -186,7 +187,8 @@ void http_post_deinit(UDF_INIT *initid)
   /* if we allocated initid->ptr, free it here */
   st_curl_results *res= (st_curl_results *)initid->ptr;
 
-  free(res->result);
+  if (res->result)
+    free(res->result);
   free(res);
   return;
 }
@@ -261,7 +263,8 @@ void http_put_deinit(UDF_INIT *initid)
   /* if we allocated initid->ptr, free it here */
   st_curl_results *res= (st_curl_results *)initid->ptr;
 
-  free(res->result);
+  if (res->result)
+    free(res->result);
   free(res);
   return;
 }
@@ -331,7 +334,8 @@ void http_delete_deinit(UDF_INIT *initid)
   /* if we allocated initid->ptr, free it here */
   st_curl_results *res= (st_curl_results *)initid->ptr;
 
-  free(res->result);
+  if (res->result)
+    free(res->result);
   free(res);
   return;
 }

--- a/src/mysql-udf-http.c
+++ b/src/mysql-udf-http.c
@@ -102,11 +102,6 @@ char *http_get(UDF_INIT *initid, UDF_ARGS *args,
       res->size = 0;
     }
   }
-  else
-  {
-    strcpy(res->result,"");
-    *length= 0;
-  }
   curl_easy_cleanup(curl);
   *length= res->size;
   return ((char *) res->result);
@@ -180,11 +175,6 @@ char *http_post(UDF_INIT *initid, UDF_ARGS *args,
         strcpy(res->result,"");
       res->size = 0;
     }
-  }
-  else
-  {
-    strcpy(res->result,"");
-    *length= 0;
   }
   curl_easy_cleanup(curl);
   *length= res->size;
@@ -261,11 +251,6 @@ char *http_put(UDF_INIT *initid, UDF_ARGS *args,
       res->size = 0;
     }
   }
-  else
-  {
-    strcpy(res->result,"");
-    *length= 0;
-  }
   curl_easy_cleanup(curl);
   *length= res->size;
   return ((char *) res->result);
@@ -335,11 +320,6 @@ char *http_delete(UDF_INIT *initid, UDF_ARGS *args,
         strcpy(res->result,"");
       res->size = 0;
     }
-  }
-  else
-  {
-    strcpy(res->result,"");
-    *length= 0;
   }
   curl_easy_cleanup(curl);
   *length= res->size;

--- a/src/mysql-udf-http.c
+++ b/src/mysql-udf-http.c
@@ -97,8 +97,9 @@ char *http_get(UDF_INIT *initid, UDF_ARGS *args,
     retref= curl_easy_perform(curl);
     if (retref) {
       fprintf(stderr, "error\n");
-      strcpy(res->result,"");
       *length= 0;
+      if (res->result) 
+        strcpy(res->result,"");
     }
   }
   else
@@ -175,8 +176,9 @@ char *http_post(UDF_INIT *initid, UDF_ARGS *args,
     retref= curl_easy_perform(curl);
     if (retref) {
       fprintf(stderr, "error\n");
-      strcpy(res->result,"");
       *length= 0;
+      if (res->result)
+        strcpy(res->result,"");
     }
   }
   else
@@ -254,8 +256,9 @@ char *http_put(UDF_INIT *initid, UDF_ARGS *args,
     retref= curl_easy_perform(curl);
     if (retref) {
       fprintf(stderr, "error\n");
-      strcpy(res->result,"");
       *length= 0;
+      if (res->result)
+        strcpy(res->result,"");
     }
   }
   else
@@ -328,8 +331,9 @@ char *http_delete(UDF_INIT *initid, UDF_ARGS *args,
     retref= curl_easy_perform(curl);
     if (retref) {
       fprintf(stderr, "error\n");
-      strcpy(res->result,"");
       *length= 0;
+      if (res->result)
+        strcpy(res->result,"");
     }
   }
   else

--- a/src/mysql-udf-http.c
+++ b/src/mysql-udf-http.c
@@ -97,9 +97,9 @@ char *http_get(UDF_INIT *initid, UDF_ARGS *args,
     retref= curl_easy_perform(curl);
     if (retref) {
       fprintf(stderr, "error\n");
-      *length= 0;
       if (res->result) 
         strcpy(res->result,"");
+      res->size = 0;
     }
   }
   else
@@ -176,9 +176,9 @@ char *http_post(UDF_INIT *initid, UDF_ARGS *args,
     retref= curl_easy_perform(curl);
     if (retref) {
       fprintf(stderr, "error\n");
-      *length= 0;
       if (res->result)
         strcpy(res->result,"");
+      res->size = 0;
     }
   }
   else
@@ -256,9 +256,9 @@ char *http_put(UDF_INIT *initid, UDF_ARGS *args,
     retref= curl_easy_perform(curl);
     if (retref) {
       fprintf(stderr, "error\n");
-      *length= 0;
       if (res->result)
         strcpy(res->result,"");
+      res->size = 0;
     }
   }
   else
@@ -331,9 +331,9 @@ char *http_delete(UDF_INIT *initid, UDF_ARGS *args,
     retref= curl_easy_perform(curl);
     if (retref) {
       fprintf(stderr, "error\n");
-      *length= 0;
       if (res->result)
         strcpy(res->result,"");
+      res->size = 0;
     }
   }
   else


### PR DESCRIPTION
This issue has imported from below and all of patches written by mindw0rm.
https://code.google.com/p/mysql-udf-http/issues/detail?id=3

> Reported by mindw...@web.de, Aug 22, 2013
> When specifying an unknown host, a segmentation fault occurs:
> mysql> select http_get('http://example.invalid/');
> ERROR 2013 (HY000): Lost connection to MySQL server during query
> mysql> 
> 
> The mysql error log says "mysqld got signal 11 ;"
> 
> After some debugging I found that in that case result->res ist still NULL after curl_easy_perform. The error is caused by 
> strcopy(res->result, "")
